### PR TITLE
Update PlayerMoveListener.java

### DIFF
--- a/src/main/java/com/iridium/iridiumteams/listeners/PlayerMoveListener.java
+++ b/src/main/java/com/iridium/iridiumteams/listeners/PlayerMoveListener.java
@@ -28,8 +28,7 @@ public class PlayerMoveListener<T extends Team, U extends IridiumUser<T>> implem
         Location from = event.getFrom();
 
         // might help speed things up - if the next location does not change blocks, why do anything?
-        // we don't need to check y, since we don't check anything against verticality.
-        if ((from.getBlockX() == to.getBlockX()) && (from.getZ() == to.getBlockZ())) return;
+        if ((from.getBlockX() == to.getBlockX()) && (from.getBlockZ() == to.getBlockZ()) && (from.getBlockY() == to.getBlockY())) return;
 
         Player player = event.getPlayer();
 


### PR DESCRIPTION
we were checking z more than x, and we may include checks for y in the future (including with iridiumskyblock)