### PR TITLE
Added return statement infront of WEEKLY mission

### DIFF
--- a/src/main/java/com/iridium/iridiumteams/managers/MissionManager.java
+++ b/src/main/java/com/iridium/iridiumteams/managers/MissionManager.java
@@ -32,7 +32,7 @@ public class MissionManager<T extends Team, U extends IridiumUser<T>> {
             case DAILY:
                 return baseTime.plusDays(1);
             case WEEKLY:
-                baseTime.with(TemporalAdjusters.next(DayOfWeek.MONDAY));
+                return baseTime.with(TemporalAdjusters.next(DayOfWeek.MONDAY));
             case INFINITE:
                 return null;
         }


### PR DESCRIPTION
Added a return statement for the timed WEEKLY missions, not sure if this is entirely needed or necessary since it seems WEEKLY was turned to disabled, but I was hoping to use it!