### PR TITLE
feat: add delayed teleportation system for teams

### DIFF
--- a/src/main/java/com/iridium/iridiumteams/IridiumTeams.java
+++ b/src/main/java/com/iridium/iridiumteams/IridiumTeams.java
@@ -204,6 +204,7 @@ public abstract class IridiumTeams<T extends Team, U extends IridiumUser<T>> ext
         Bukkit.getPluginManager().registerEvents(new SettingUpdateListener<>(this), this);
         Bukkit.getPluginManager().registerEvents(new EntityDamageListener<>(this), this);
         Bukkit.getPluginManager().registerEvents(new PlayerBucketListener<>(this), this);
+        Bukkit.getPluginManager().registerEvents(new TeleportListener<>(this), this);
     }
 
     public void saveData() {

--- a/src/main/java/com/iridium/iridiumteams/IridiumTeams.java
+++ b/src/main/java/com/iridium/iridiumteams/IridiumTeams.java
@@ -13,6 +13,7 @@ import com.iridium.iridiumteams.managers.*;
 import com.iridium.iridiumteams.placeholders.ClipPlaceholderAPI;
 import com.iridium.iridiumteams.sorting.TeamSorting;
 import de.jeff_media.updatechecker.UpdateChecker;
+import com.iridium.iridiumteams.teleport.TeleportManager;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -98,6 +99,8 @@ public abstract class IridiumTeams<T extends Team, U extends IridiumUser<T>> ext
     public abstract TeamManager<T, U> getTeamManager();
 
     public abstract IridiumUserManager<T, U> getUserManager();
+
+    public abstract TeleportManager<T, U> getTeleportManager();
 
     public abstract CommandManager<T, U> getCommandManager();
 

--- a/src/main/java/com/iridium/iridiumteams/commands/HomeCommand.java
+++ b/src/main/java/com/iridium/iridiumteams/commands/HomeCommand.java
@@ -21,22 +21,14 @@ public class HomeCommand<T extends Team, U extends IridiumUser<T>> extends Comma
         Player player = user.getPlayer();
         Location home = team.getHome();
         if (home == null) {
-            player.sendMessage(StringUtils.color(iridiumTeams.getMessages().homeNotSet
-                    .replace("%prefix%", iridiumTeams.getConfiguration().prefix)
-            ));
+            player.sendMessage(StringUtils.color(iridiumTeams.getMessages().homeNotSet.replace("%prefix%", iridiumTeams.getConfiguration().prefix)));
             return false;
         }
         if (iridiumTeams.getTeamManager().getTeamViaLocation(home).map(T::getId).orElse(0) != team.getId()) {
-            player.sendMessage(StringUtils.color(iridiumTeams.getMessages().homeNotInTeam
-                    .replace("%prefix%", iridiumTeams.getConfiguration().prefix)
-            ));
+            player.sendMessage(StringUtils.color(iridiumTeams.getMessages().homeNotInTeam.replace("%prefix%", iridiumTeams.getConfiguration().prefix)));
             return false;
         }
-        if (iridiumTeams.getTeamManager().teleport(player, home, team)) {
-            player.sendMessage(StringUtils.color(iridiumTeams.getMessages().teleportingHome
-                    .replace("%prefix%", iridiumTeams.getConfiguration().prefix)
-            ));
-        }
+        iridiumTeams.getTeamManager().teleportToHome(player, home, team);
         return true;
     }
 

--- a/src/main/java/com/iridium/iridiumteams/commands/WarpCommand.java
+++ b/src/main/java/com/iridium/iridiumteams/commands/WarpCommand.java
@@ -40,14 +40,8 @@ public class WarpCommand<T extends Team, U extends IridiumUser<T>> extends Comma
                 return false;
             }
         }
-        
-        if (iridiumTeams.getTeamManager().teleport(player, teamWarp.get().getLocation(), team)) {
-            player.sendMessage(StringUtils.color(iridiumTeams.getMessages().teleportingWarp
-                    .replace("%prefix%", iridiumTeams.getConfiguration().prefix)
-                    .replace("%name%", teamWarp.get().getName())
-            ));
-        }
 
+        iridiumTeams.getTeamManager().teleportToWarp(player, teamWarp.get().getLocation(), team, teamWarp.get().getName());
         return true;
     }
 

--- a/src/main/java/com/iridium/iridiumteams/configs/Configuration.java
+++ b/src/main/java/com/iridium/iridiumteams/configs/Configuration.java
@@ -40,7 +40,9 @@ public class Configuration {
     public Map<Integer, Integer> teamTopSlots;
 
     public Map<Integer, Integer> teamWarpSlots;
-
+    public int teleportDelay;
+    public double teleportMovementThreshold;
+    public String teleportBypassPermission;
 
     /**
      * The Rewards the island gets for leveling up
@@ -116,15 +118,15 @@ public class Configuration {
                 .build();
 
         this.levelRewards = ImmutableMap.<Integer, Reward>builder()
-                .put(1, new Reward(new Item(XMaterial.EXPERIENCE_BOTTLE, 1, "&b&lLevel %"+team.toLowerCase()+"_level% Reward", Arrays.asList(
-                        "&7"+team+" Level %"+team.toLowerCase()+"_level% Rewards:",
+                .put(1, new Reward(new Item(XMaterial.EXPERIENCE_BOTTLE, 1, "&b&lLevel %" + team.toLowerCase() + "_level% Reward", Arrays.asList(
+                        "&7" + team + " Level %" + team.toLowerCase() + "_level% Rewards:",
                         "&b&l* &b200 Money",
                         "",
                         "&b&l[!] &bLeft click to redeem"
                 )), Collections.emptyList(), 0, new HashMap<>(), 200, 0, XSound.ENTITY_PLAYER_LEVELUP))
 
-                .put(5, new Reward(new Item(XMaterial.EXPERIENCE_BOTTLE, 1, "&b&lLevel %"+team.toLowerCase()+"_level% Reward", Arrays.asList(
-                        "&7"+team+" Level %"+team.toLowerCase()+"_level% Rewards:",
+                .put(5, new Reward(new Item(XMaterial.EXPERIENCE_BOTTLE, 1, "&b&lLevel %" + team.toLowerCase() + "_level% Reward", Arrays.asList(
+                        "&7" + team + " Level %" + team.toLowerCase() + "_level% Rewards:",
                         "&b&l* &b2000 Money",
                         "",
                         "&b&l[!] &bLeft click to redeem"
@@ -132,5 +134,8 @@ public class Configuration {
                 .build();
 
         this.whitelistedWorlds = Collections.emptyList();
+        this.teleportDelay = 0;
+        this.teleportMovementThreshold = 0.5;
+        this.teleportBypassPermission = pluginName.toLowerCase().replace(" ", "") + ".teleport.bypass";
     }
 }

--- a/src/main/java/com/iridium/iridiumteams/configs/Messages.java
+++ b/src/main/java/com/iridium/iridiumteams/configs/Messages.java
@@ -166,6 +166,11 @@ public class Messages {
     public String topFirstColor;
     public String topSecondColor;
     public String topThirdColor;
+    public String teleportStarted;
+    public String teleportDelay;
+    public String teleportCancelled;
+    public String teleportCancelledMovement;
+    public String teleportCancelledDamage;
 
     public Messages() {
         this("Team", "t", "IridiumTeams", "&c");
@@ -335,5 +340,10 @@ public class Messages {
         topFirstColor = "&e&l";
         topSecondColor = "&l";
         topThirdColor = "&6";
+        teleportStarted = "%prefix% Teleporting...";
+        teleportDelay = "%prefix% Teleporting in %delay% seconds. Don't move!";
+        teleportCancelled = "%prefix% Teleport cancelled.";
+        teleportCancelledMovement = "%prefix% Teleport cancelled because you moved!";
+        teleportCancelledDamage = "%prefix% Teleport cancelled because you took damage!";
     }
 }

--- a/src/main/java/com/iridium/iridiumteams/listeners/TeleportListener.java
+++ b/src/main/java/com/iridium/iridiumteams/listeners/TeleportListener.java
@@ -39,14 +39,14 @@ public class TeleportListener<T extends Team, U extends IridiumUser<T>> implemen
         TeleportManager<T, U> teleportManager = iridiumTeams.getTeleportManager();
         TeleportRequest<T, U> request = teleportManager.getTeleportRequest(playerId);
 
-        if (request != null) {
-            if (event.getFrom().getBlockX() != event.getTo().getBlockX() ||
-                    event.getFrom().getBlockY() != event.getTo().getBlockY() ||
-                    event.getFrom().getBlockZ() != event.getTo().getBlockZ()) {
+        if (request == null) return;
 
-                if (request.hasPlayerMoved(iridiumTeams.getConfiguration().teleportMovementThreshold)) {
-                    teleportManager.cancelTeleport(playerId, TeleportCancelReason.PLAYER_MOVED);
-                }
+
+        if (event.getFrom().getBlockX() != event.getTo().getBlockX() ||
+                event.getFrom().getBlockY() != event.getTo().getBlockY() ||
+                event.getFrom().getBlockZ() != event.getTo().getBlockZ()) {
+            if (request.hasPlayerMoved(iridiumTeams.getConfiguration().teleportMovementThreshold)) {
+                teleportManager.cancelTeleport(playerId, TeleportCancelReason.PLAYER_MOVED);
             }
         }
     }

--- a/src/main/java/com/iridium/iridiumteams/listeners/TeleportListener.java
+++ b/src/main/java/com/iridium/iridiumteams/listeners/TeleportListener.java
@@ -1,0 +1,111 @@
+package com.iridium.iridiumteams.listeners;
+
+import com.iridium.iridiumteams.IridiumTeams;
+import com.iridium.iridiumteams.database.IridiumUser;
+import com.iridium.iridiumteams.database.Team;
+import com.iridium.iridiumteams.teleport.TeleportCancelReason;
+import com.iridium.iridiumteams.teleport.TeleportManager;
+import com.iridium.iridiumteams.teleport.TeleportRequest;
+import lombok.AllArgsConstructor;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+import java.util.UUID;
+
+/**
+ * Handles events that should cancel delayed teleports
+ */
+@AllArgsConstructor
+public class TeleportListener<T extends Team, U extends IridiumUser<T>> implements Listener {
+
+    private final IridiumTeams<T, U> iridiumTeams;
+
+    /**
+     * Cancel teleport if player moves beyond threshold
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        UUID playerId = player.getUniqueId();
+
+        TeleportManager<T, U> teleportManager = iridiumTeams.getTeleportManager();
+        TeleportRequest<T, U> request = teleportManager.getTeleportRequest(playerId);
+
+        if (request != null) {
+            if (event.getFrom().getBlockX() != event.getTo().getBlockX() ||
+                    event.getFrom().getBlockY() != event.getTo().getBlockY() ||
+                    event.getFrom().getBlockZ() != event.getTo().getBlockZ()) {
+
+                if (request.hasPlayerMoved(iridiumTeams.getConfiguration().teleportMovementThreshold)) {
+                    teleportManager.cancelTeleport(playerId, TeleportCancelReason.PLAYER_MOVED);
+                }
+            }
+        }
+    }
+
+    /**
+     * Cancel teleport if player takes damage
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntityDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player)) {
+            return;
+        }
+
+        Player player = (Player) event.getEntity();
+        UUID playerId = player.getUniqueId();
+
+        TeleportManager<T, U> teleportManager = iridiumTeams.getTeleportManager();
+        if (teleportManager.hasActiveTeleport(playerId)) {
+            teleportManager.cancelTeleport(playerId, TeleportCancelReason.PLAYER_DAMAGED);
+        }
+    }
+
+    /**
+     * Cancel teleport if player quits
+     */
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        UUID playerId = player.getUniqueId();
+
+        TeleportManager<T, U> teleportManager = iridiumTeams.getTeleportManager();
+        if (teleportManager.hasActiveTeleport(playerId)) {
+            teleportManager.cancelTeleport(playerId, TeleportCancelReason.PLAYER_OFFLINE);
+        }
+    }
+
+    /**
+     * Cancel teleport if player teleports via another method
+     * (but allow the intended delayed teleport to go through)
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerTeleport(PlayerTeleportEvent event) {
+        Player player = event.getPlayer();
+        UUID playerId = player.getUniqueId();
+
+        TeleportManager<T, U> teleportManager = iridiumTeams.getTeleportManager();
+        TeleportRequest<T, U> request = teleportManager.getTeleportRequest(playerId);
+
+        if (request != null) {
+            if (locationsAreClose(event.getTo(), request.getDestination(), 0.5)) {
+                teleportManager.cancelTeleport(playerId, TeleportCancelReason.OTHER_TELEPORT);
+            }
+        }
+    }
+
+    private boolean locationsAreClose(Location loc1, Location loc2, double threshold) {
+        if (!loc1.getWorld().equals(loc2.getWorld())) {
+            return false;
+        }
+        return loc1.distance(loc2) <= threshold;
+    }
+}

--- a/src/main/java/com/iridium/iridiumteams/managers/TeamManager.java
+++ b/src/main/java/com/iridium/iridiumteams/managers/TeamManager.java
@@ -11,6 +11,7 @@ import com.iridium.iridiumteams.enhancements.EnhancementData;
 import com.iridium.iridiumteams.missions.Mission;
 import com.iridium.iridiumteams.missions.MissionType;
 import com.iridium.iridiumteams.sorting.TeamSorting;
+import com.iridium.iridiumteams.teleport.TeleportType;
 import com.iridium.iridiumteams.utils.PlayerUtils;
 import de.tr7zw.changeme.nbtapi.NBT;
 import de.tr7zw.changeme.nbtapi.NBTType;
@@ -438,6 +439,49 @@ public abstract class TeamManager<T extends Team, U extends IridiumUser<T>> {
         PaperLib.teleportAsync(player, location);
         player.teleport(location);
         return true;
+    }
+
+    /**
+     * Teleport a player with delay using the TeleportManager
+     *
+     * @param player       The player to teleport
+     * @param location     The destination location
+     * @param team         The team associated with this teleport
+     * @param teleportType The type of teleport (HOME, WARP, etc.)
+     * @param teleportName The name of the teleport (for warps)
+     * @return true if teleport was initiated successfully
+     */
+    public boolean teleportWithDelay(Player player, Location location, T team,
+                                     TeleportType teleportType,
+                                     String teleportName) {
+        return iridiumTeams.getTeleportManager().startTeleport(player, location, team, teleportType, teleportName);
+    }
+
+    /**
+     * Teleport a player to team home with delay
+     *
+     * @param player   The player to teleport
+     * @param location The home location
+     * @param team     The team
+     * @return true if teleport was initiated successfully
+     */
+    public boolean teleportToHome(Player player, Location location, T team) {
+        return teleportWithDelay(player, location, team,
+                TeleportType.HOME, "home");
+    }
+
+    /**
+     * Teleport a player to a team warp with delay
+     *
+     * @param player   The player to teleport
+     * @param location The warp location
+     * @param team     The team
+     * @param warpName The name of the warp
+     * @return true if teleport was initiated successfully
+     */
+    public boolean teleportToWarp(Player player, Location location, T team, String warpName) {
+        return teleportWithDelay(player, location, team,
+                TeleportType.WARP, warpName);
     }
 
     public void handleBlockBreakOutsideTerritory(BlockBreakEvent blockEvent) {

--- a/src/main/java/com/iridium/iridiumteams/teleport/TeleportCancelReason.java
+++ b/src/main/java/com/iridium/iridiumteams/teleport/TeleportCancelReason.java
@@ -1,0 +1,36 @@
+package com.iridium.iridiumteams.teleport;
+
+/**
+ * Enumeration of reasons why a teleport might be cancelled
+ */
+public enum TeleportCancelReason {
+    /**
+     * Player moved beyond the allowed threshold
+     */
+    PLAYER_MOVED,
+    
+    /**
+     * Player took damage
+     */
+    PLAYER_DAMAGED,
+    
+    /**
+     * Player went offline
+     */
+    PLAYER_OFFLINE,
+    
+    /**
+     * Player initiated a new teleport request
+     */
+    NEW_REQUEST,
+    
+    /**
+     * Player teleported via another method
+     */
+    OTHER_TELEPORT,
+    
+    /**
+     * Others idk
+     */
+    OTHER
+}

--- a/src/main/java/com/iridium/iridiumteams/teleport/TeleportManager.java
+++ b/src/main/java/com/iridium/iridiumteams/teleport/TeleportManager.java
@@ -46,12 +46,12 @@ public class TeleportManager<T extends Team, U extends IridiumUser<T>> {
         }
 
         if (player.hasPermission(iridiumTeams.getConfiguration().teleportBypassPermission)) {
-            return instantTeleport(player, destination, team);
+            return instantTeleport(player, destination);
         }
 
         int delay = iridiumTeams.getConfiguration().teleportDelay;
         if (delay <= 0) {
-            return instantTeleport(player, destination, team);
+            return instantTeleport(player, destination);
         }
 
         TeleportRequest<T, U> request = new TeleportRequest<>(
@@ -117,10 +117,9 @@ public class TeleportManager<T extends Team, U extends IridiumUser<T>> {
      * 
      * @param player      The player to teleport
      * @param destination The destination location
-     * @param team        The team associated with this teleport
      * @return true if teleport was successful
      */
-    private boolean instantTeleport(Player player, Location destination, T team) {
+    private boolean instantTeleport(Player player, Location destination) {
         player.setFallDistance(0);
         PaperLib.teleportAsync(player, destination);
         player.teleport(destination);
@@ -191,7 +190,7 @@ public class TeleportManager<T extends Team, U extends IridiumUser<T>> {
                 }
                 activeRequests.remove(playerId);
 
-                instantTeleport(player, request.getDestination(), request.getTeam());
+                instantTeleport(player, request.getDestination());
                 sendSuccessMessage(player, request);
             }
         };

--- a/src/main/java/com/iridium/iridiumteams/teleport/TeleportManager.java
+++ b/src/main/java/com/iridium/iridiumteams/teleport/TeleportManager.java
@@ -1,0 +1,256 @@
+package com.iridium.iridiumteams.teleport;
+
+import com.iridium.iridiumcore.utils.StringUtils;
+import com.iridium.iridiumteams.IridiumTeams;
+import com.iridium.iridiumteams.database.IridiumUser;
+import com.iridium.iridiumteams.database.Team;
+import io.papermc.lib.PaperLib;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages delayed teleportation for IridiumTeams
+ */
+public class TeleportManager<T extends Team, U extends IridiumUser<T>> {
+
+    private final IridiumTeams<T, U> iridiumTeams;
+    private final Map<UUID, TeleportRequest<T, U>> activeRequests = new ConcurrentHashMap<>();
+
+    public TeleportManager(IridiumTeams<T, U> iridiumTeams) {
+        this.iridiumTeams = iridiumTeams;
+    }
+
+    /**
+     * Start a delayed teleport for a player
+     * 
+     * @param player       The player to teleport
+     * @param destination  The destination location
+     * @param team         The team associated with this teleport
+     * @param teleportType The type of teleport (HOME, WARP, etc.)
+     * @param teleportName The name of the teleport (for warps)
+     * @return true if teleport was started, false if player already has an active
+     *         request
+     */
+    public boolean startTeleport(Player player, Location destination, T team,
+            TeleportType teleportType, String teleportName) {
+        UUID playerId = player.getUniqueId();
+
+        if (activeRequests.containsKey(playerId)) {
+            cancelTeleport(playerId, TeleportCancelReason.NEW_REQUEST);
+        }
+
+        if (player.hasPermission(iridiumTeams.getConfiguration().teleportBypassPermission)) {
+            return instantTeleport(player, destination, team);
+        }
+
+        int delay = iridiumTeams.getConfiguration().teleportDelay;
+        if (delay <= 0) {
+            return instantTeleport(player, destination, team);
+        }
+
+        TeleportRequest<T, U> request = new TeleportRequest<>(
+                playerId, destination, player.getLocation(),
+                teleportType, team, teleportName, delay);
+
+        activeRequests.put(playerId, request);
+
+        player.sendMessage(StringUtils.color(iridiumTeams.getMessages().teleportStarted
+                .replace("%prefix%", iridiumTeams.getConfiguration().prefix)));
+
+        startCountdownTask(request);
+        startDelayTask(request);
+
+        return true;
+    }
+
+    /**
+     * Cancel a player's teleport request
+     * 
+     * @param playerId The player's UUID
+     * @param reason   The reason for cancellation
+     */
+    public void cancelTeleport(UUID playerId, TeleportCancelReason reason) {
+        TeleportRequest<T, U> request = activeRequests.remove(playerId);
+        
+        if (request == null) return;
+        request.cancelTasks();
+
+        Player player = request.getPlayer();
+        if (player != null && player.isOnline()) {
+            String message = getTeleportCancelMessage(reason);
+            if (message != null) {
+                player.sendMessage(StringUtils.color(message
+                        .replace("%prefix%", iridiumTeams.getConfiguration().prefix)));
+            }
+        }
+
+    }
+
+    /**
+     * Get a player's active teleport request
+     * 
+     * @param playerId The player's UUID
+     * @return The teleport request or null if none exists
+     */
+    public TeleportRequest<T, U> getTeleportRequest(UUID playerId) {
+        return activeRequests.get(playerId);
+    }
+
+    /**
+     * Check if a player has an active teleport request
+     * 
+     * @param playerId The player's UUID
+     * @return true if player has an active request
+     */
+    public boolean hasActiveTeleport(UUID playerId) {
+        return activeRequests.containsKey(playerId);
+    }
+
+    /**
+     * Perform an instant teleport without delay
+     * 
+     * @param player      The player to teleport
+     * @param destination The destination location
+     * @param team        The team associated with this teleport
+     * @return true if teleport was successful
+     */
+    private boolean instantTeleport(Player player, Location destination, T team) {
+        player.setFallDistance(0);
+        PaperLib.teleportAsync(player, destination);
+        player.teleport(destination);
+        return true;
+    }
+
+    /**
+     * Start the countdown task for a teleport request
+     * 
+     * @param request The teleport request
+     */
+    private void startCountdownTask(TeleportRequest<T, U> request) {
+        BukkitRunnable countdownTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                Player player = request.getPlayer();
+                if (player == null || !player.isOnline()) {
+                    cancelTeleport(request.getPlayerId(), TeleportCancelReason.PLAYER_OFFLINE);
+                    return;
+                }
+
+                if (request.hasPlayerMoved(iridiumTeams.getConfiguration().teleportMovementThreshold)) {
+                    cancelTeleport(request.getPlayerId(), TeleportCancelReason.PLAYER_MOVED);
+                    return;
+                }
+
+                if (request.getRemainingSeconds() > 0) {
+                    player.sendMessage(StringUtils.color(iridiumTeams.getMessages().teleportDelay
+                            .replace("%prefix%", iridiumTeams.getConfiguration().prefix)
+                            .replace("%delay%", String.valueOf(request.getRemainingSeconds()))));
+
+                    request.setRemainingSeconds(request.getRemainingSeconds() - 1);
+                }
+            }
+        };
+
+        request.setCountdownTask(countdownTask);
+
+        countdownTask.runTaskTimer(iridiumTeams, 0L, 20L);
+    }
+
+    /**
+     * Start the delay task for a teleport request
+     * 
+     * @param request The teleport request
+     */
+    private void startDelayTask(TeleportRequest<T, U> request) {
+        BukkitRunnable delayTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                UUID playerId = request.getPlayerId();
+                Player player = request.getPlayer();
+
+                if (player == null || !player.isOnline()) {
+                    activeRequests.remove(playerId);
+                    return;
+                }
+
+                if (request.hasPlayerMoved(iridiumTeams.getConfiguration().teleportMovementThreshold)) {
+                    cancelTeleport(playerId, TeleportCancelReason.PLAYER_MOVED);
+                    return;
+                }
+
+                if (request.getCountdownTask() != null) {
+                    request.getCountdownTask().cancel();
+                }
+                activeRequests.remove(playerId);
+
+                instantTeleport(player, request.getDestination(), request.getTeam());
+                sendSuccessMessage(player, request);
+            }
+        };
+
+        request.setDelayTask(delayTask);
+
+        long delayTicks = request.getRemainingSeconds() * 20L;
+        delayTask.runTaskLater(iridiumTeams, delayTicks);
+    }
+
+    /**
+     * Send appropriate success message after teleport
+     * 
+     * @param player  The player who teleported
+     * @param request The completed teleport request
+     */
+    private void sendSuccessMessage(Player player, TeleportRequest<T, U> request) {
+        String message;
+        switch (request.getTeleportType()) {
+            case HOME:
+                message = iridiumTeams.getMessages().teleportingHome;
+                break;
+            case WARP:
+                message = iridiumTeams.getMessages().teleportingWarp
+                        .replace("%name%", request.getTeleportName() != null ? request.getTeleportName() : "unknown");
+                break;
+            default:
+                message = iridiumTeams.getMessages().teleportStarted;
+                break; // Generic message
+        }
+
+        player.sendMessage(StringUtils.color(message
+                .replace("%prefix%", iridiumTeams.getConfiguration().prefix)));
+    }
+
+    /**
+     * Get the appropriate cancellation message for a given reason
+     * 
+     * @param reason The cancellation reason
+     * @return The message string or null if no message should be sent
+     */
+    private String getTeleportCancelMessage(TeleportCancelReason reason) {
+        switch (reason) {
+            case PLAYER_MOVED:
+                return iridiumTeams.getMessages().teleportCancelledMovement;
+            case PLAYER_DAMAGED:
+                return iridiumTeams.getMessages().teleportCancelledDamage;
+            case PLAYER_OFFLINE:
+            case NEW_REQUEST:
+                return null;
+            default:
+                return iridiumTeams.getMessages().teleportCancelled;
+        }
+    }
+
+    /**
+     * Clean up when plugin disables
+     */
+    public void shutdown() {
+        for (TeleportRequest<T, U> request : activeRequests.values()) {
+            request.cancelTasks();
+        }
+        activeRequests.clear();
+    }
+}

--- a/src/main/java/com/iridium/iridiumteams/teleport/TeleportRequest.java
+++ b/src/main/java/com/iridium/iridiumteams/teleport/TeleportRequest.java
@@ -1,0 +1,93 @@
+package com.iridium.iridiumteams.teleport;
+
+import com.iridium.iridiumteams.database.IridiumUser;
+import com.iridium.iridiumteams.database.Team;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Represents a delayed teleport request for a player
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+public class TeleportRequest<T extends Team, U extends IridiumUser<T>> {
+
+    private final UUID playerId;
+    private final Location destination;
+    private final Location originalLocation;
+    private final LocalDateTime requestTime;
+    private final TeleportType teleportType;
+    private final T team;
+    private final String teleportName; // Warp name if warp teleport
+    private BukkitRunnable delayTask;
+    private BukkitRunnable countdownTask;
+    private int remainingSeconds;
+
+    public TeleportRequest(UUID playerId, Location destination, Location originalLocation,
+            TeleportType teleportType, T team, String teleportName, int delaySeconds) {
+        this.playerId = playerId;
+        this.destination = destination;
+        this.originalLocation = originalLocation;
+        this.requestTime = LocalDateTime.now();
+        this.teleportType = teleportType;
+        this.team = team;
+        this.teleportName = teleportName;
+        this.remainingSeconds = delaySeconds;
+        this.delayTask = null;
+        this.countdownTask = null;
+    }
+
+    /**
+     * Get the player associated with this teleport request
+     * 
+     * @return Player object or null if player is offline
+     */
+    public Player getPlayer() {
+        return Bukkit.getPlayer(playerId);
+    }
+
+    /**
+     * Check if the player has moved significantly from their original location
+     * 
+     * @param threshold Movement threshold in blocks
+     * @return true if player has moved beyond threshold
+     */
+    public boolean hasPlayerMoved(double threshold) {
+        Player player = getPlayer();
+        if (player == null)
+            return true;
+
+        Location currentLocation = player.getLocation();
+
+        // Check if they're in the same world
+        if (!currentLocation.getWorld().equals(originalLocation.getWorld())) {
+            return true;
+        }
+
+        // Calculate distance moved
+        double distance = currentLocation.distance(originalLocation);
+        return distance > threshold;
+    }
+
+    /**
+     * Cancel any running tasks associated with this teleport request
+     */
+    public void cancelTasks() {
+        if (delayTask != null && !delayTask.isCancelled()) {
+            delayTask.cancel();
+        }
+        if (countdownTask != null && !countdownTask.isCancelled()) {
+            countdownTask.cancel();
+        }
+    }
+}

--- a/src/main/java/com/iridium/iridiumteams/teleport/TeleportRequest.java
+++ b/src/main/java/com/iridium/iridiumteams/teleport/TeleportRequest.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -50,10 +51,10 @@ public class TeleportRequest<T extends Team, U extends IridiumUser<T>> {
     /**
      * Get the player associated with this teleport request
      * 
-     * @return Player object or null if player is offline
+     * @return Optional containing the Player object, or empty if player is offline
      */
-    public Player getPlayer() {
-        return Bukkit.getPlayer(playerId);
+    public Optional<Player> getPlayer() {
+        return Optional.ofNullable(Bukkit.getPlayer(playerId));
     }
 
     /**
@@ -63,10 +64,10 @@ public class TeleportRequest<T extends Team, U extends IridiumUser<T>> {
      * @return true if player has moved beyond threshold
      */
     public boolean hasPlayerMoved(double threshold) {
-        Player player = getPlayer();
-        if (player == null)
-            return true;
+        Optional<Player> optionalPlayer = getPlayer();
+        if (!optionalPlayer.isPresent()) return true;
 
+        Player player = optionalPlayer.get();
         Location currentLocation = player.getLocation();
 
         // Check if they're in the same world

--- a/src/main/java/com/iridium/iridiumteams/teleport/TeleportType.java
+++ b/src/main/java/com/iridium/iridiumteams/teleport/TeleportType.java
@@ -1,0 +1,21 @@
+package com.iridium.iridiumteams.teleport;
+
+/**
+ * Enumeration of different types of teleportation in IridiumTeams
+ */
+public enum TeleportType {
+    /**
+     * Teleporting to team home
+     */
+    HOME,
+    
+    /**
+     * Teleporting to a team warp
+     */
+    WARP,
+    
+    /**
+     * Teleporting via other means just in case
+     */
+    OTHER
+}


### PR DESCRIPTION
Introduces a new delayed teleportation system with movement and damage cancellation for team home and warp teleports. Adds TeleportManager, TeleportRequest, TeleportType, and TeleportCancelReason classes, a TeleportListener for event handling, and new configuration and message options for teleport delay and cancellation. Updates TeamManager and related commands to use the new system.

Closes [IridiumSkyblock/issues/936](https://github.com/Iridium-Development/IridiumSkyblock/issues/936)