### PR TITLE
Fix: Prevent piston heads from extending outside island/claim territory

### DIFF
--- a/src/main/java/com/iridium/iridiumteams/listeners/BlockPistonListener.java
+++ b/src/main/java/com/iridium/iridiumteams/listeners/BlockPistonListener.java
@@ -33,7 +33,6 @@ public class BlockPistonListener<T extends Team, U extends IridiumUser<T>> imple
         Optional<T> team = iridiumTeams.getTeamManager().getTeamViaLocation(event.getBlock().getLocation());
         if (team.isPresent()) {
             int teamId = team.get().getId();
-            int[] offset = offsets.get(event.getDirection());
 
             Block targetBlock = event.getBlock().getRelative(event.getDirection());
             Optional<T> targetTeam = iridiumTeams.getTeamManager().getTeamViaLocation(targetBlock.getLocation(), team);
@@ -42,6 +41,7 @@ public class BlockPistonListener<T extends Team, U extends IridiumUser<T>> imple
                 return;
             }
 
+            int[] offset = offsets.get(event.getDirection());
             for (Block block : event.getBlocks()) {
                 Optional<T> newTeam = iridiumTeams.getTeamManager().getTeamViaLocation(block.getLocation().add(offset[0], offset[1], offset[2]), team);
                 if (!newTeam.isPresent() || newTeam.get().getId() != teamId) {

--- a/src/main/java/com/iridium/iridiumteams/listeners/BlockPistonListener.java
+++ b/src/main/java/com/iridium/iridiumteams/listeners/BlockPistonListener.java
@@ -32,8 +32,16 @@ public class BlockPistonListener<T extends Team, U extends IridiumUser<T>> imple
     public void onBlockPistonExtend(BlockPistonExtendEvent event) {
         Optional<T> team = iridiumTeams.getTeamManager().getTeamViaLocation(event.getBlock().getLocation());
         int currentTeam = team.map(T::getId).orElse(0);
+        int[] offset = offsets.get(event.getDirection());
+
+        Block targetBlock = event.getBlock().getRelative(event.getDirection());
+        Optional<T> headTeam = iridiumTeams.getTeamManager().getTeamViaLocation(targetBlock.getLocation(), team);
+        if (headTeam.map(T::getId).orElse(0) != currentTeam) {
+            event.setCancelled(true);
+            return;
+        }
+
         for (Block block : event.getBlocks()) {
-            int[] offset = offsets.get(event.getDirection());
             Optional<T> newTeam = iridiumTeams.getTeamManager().getTeamViaLocation(block.getLocation().add(offset[0], offset[1], offset[2]), team);
             if (newTeam.map(T::getId).orElse(0) != currentTeam) {
                 event.setCancelled(true);

--- a/src/main/java/com/iridium/iridiumteams/listeners/BlockPistonListener.java
+++ b/src/main/java/com/iridium/iridiumteams/listeners/BlockPistonListener.java
@@ -31,21 +31,23 @@ public class BlockPistonListener<T extends Team, U extends IridiumUser<T>> imple
     @EventHandler(ignoreCancelled = true)
     public void onBlockPistonExtend(BlockPistonExtendEvent event) {
         Optional<T> team = iridiumTeams.getTeamManager().getTeamViaLocation(event.getBlock().getLocation());
-        int currentTeam = team.map(T::getId).orElse(0);
-        int[] offset = offsets.get(event.getDirection());
+        if (team.isPresent()) {
+            int teamId = team.get().getId();
+            int[] offset = offsets.get(event.getDirection());
 
-        Block targetBlock = event.getBlock().getRelative(event.getDirection());
-        Optional<T> headTeam = iridiumTeams.getTeamManager().getTeamViaLocation(targetBlock.getLocation(), team);
-        if (headTeam.map(T::getId).orElse(0) != currentTeam) {
-            event.setCancelled(true);
-            return;
-        }
-
-        for (Block block : event.getBlocks()) {
-            Optional<T> newTeam = iridiumTeams.getTeamManager().getTeamViaLocation(block.getLocation().add(offset[0], offset[1], offset[2]), team);
-            if (newTeam.map(T::getId).orElse(0) != currentTeam) {
+            Block targetBlock = event.getBlock().getRelative(event.getDirection());
+            Optional<T> targetTeam = iridiumTeams.getTeamManager().getTeamViaLocation(targetBlock.getLocation(), team);
+            if (!targetTeam.isPresent() || targetTeam.get().getId() != teamId) {
                 event.setCancelled(true);
                 return;
+            }
+
+            for (Block block : event.getBlocks()) {
+                Optional<T> newTeam = iridiumTeams.getTeamManager().getTeamViaLocation(block.getLocation().add(offset[0], offset[1], offset[2]), team);
+                if (!newTeam.isPresent() || newTeam.get().getId() != teamId) {
+                    event.setCancelled(true);
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
<img width="991" height="779" alt="image" src="https://github.com/user-attachments/assets/afd2f611-4bec-4095-8c63-71c8c739eead" />

**Root cause** :  When a piston extends, the handler checked whether each pushed block's destination was within the same team territory : but it never checked where the piston head itself would appear (the block directly in front of the piston base). If no blocks were being pushed (`event.getBlocks()` empty, piston extending into air), the loop didn't execute at all, so no border check occurred and the head could extend outside the island.

**Fix**: Before the existing loop, a new check retrieves the block at `pistonBase` + direction via `getRelative()` and verifies it's in the same team as the piston base. If it's outside the territory, the event is cancelled immediately. **This ensures the piston head position is always validated, regardless of whether any blocks are being pushed.**

Closes #246 